### PR TITLE
Fix missing VERSION in database

### DIFF
--- a/tracker/database.py
+++ b/tracker/database.py
@@ -1,6 +1,6 @@
 import os, sqlite3, json, hashlib, csv, time, traceback
 from collections import Counter
-from .config import DB_NAME
+from .config import DB_NAME, VERSION
 from .utils import build_id_map, resolve_ref, extract_cards_with_details
 
 def init_db():


### PR DESCRIPTION
## Summary
- import `VERSION` into `database.py`

This prevents a crash when checking for updates during startup.

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859c258a0208328b7209faf0c0f256c